### PR TITLE
fbb: Handle WL2K v4 aka "AWS" protocol changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2016 Martin Hebnes Pedersen (LA5NTA)
+Copyright (c) 2014-2017 Martin Hebnes Pedersen (LA5NTA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The winlink development team did a full scale CMS v4 test today, routing all traffic to a new AWS deployed CMS system.

Some incompatible changes to the protocol is apparently going to be introduced:
* Some new ;PM prefixed lines are sent before the proposals. They include subject and sender info for each inbound proposal.
* A new ;WARNING line with a human readable description of the warning are sent between session turnover and/or proposal lines.

As there is no mention of any ; prefixed lines in the fbb protocol description I am leaning towards treating them as comments that can be ignored. I will contact WDT to get their comment on this.

Logs:

```
2017/07/16 16:54:54 Connecting to WL2K (telnet)...
2017/07/16 16:54:56 Connected to 52.72.182.128:8772 (tcp)
[WL2K-4.0-B2FWIHJM$]
;PQ: 25606151
CMS>
>FF
;WARNING: Password could not be validated for LE1OH
2017/07/16 16:54:57 Exchange failed: Unexpected response: ';WARNING: Password could not be validated for LE1OH'
```

```
2017/07/16 16:55:54 Connecting to WL2K (telnet)...
2017/07/16 16:55:55 Connected to 34.193.180.83:8772 (tcp)
[WL2K-4.0-B2FWIHJM$]
;PQ: 22790242
CMS>
>FF
;PM: LA5NTA 1ZLGURJZVG4O 481 oh5rm@----.-- //WL2K Ardop activity
2017/07/16 16:55:57 Exchange failed: Unexpected response: ';PM: LA5NTA 1ZLGURJZVG4O 481 oh5rm@----.-- //WL2K Ardop activity'
```

```
2017/07/16 18:03:23 Connecting to WL2K (telnet)...
2017/07/16 18:03:24 Connected to 34.193.180.83:8772 (tcp)
[WL2K-4.0-B2FWIHJM$]
;PQ: 09858293
CMS>
>FC EM EL7FOALYAA27 218 184 0
Sending checksum A2
;WARNING: Password could not be validated for LE1OH
2017/07/16 18:03:25 Exchange failed: Expected proposal answer from remote. Got: ';WARNING: Password could not be validated for LE1OH'
```