### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/fbb/header.go
+++ b/fbb/header.go
@@ -137,7 +137,7 @@ func (h Header) Write(w io.Writer) error {
 // (See DecodeHeader for mime.WordDecoder differences).
 type WordDecoder struct{ mime.WordDecoder }
 
-// Decode decodes an encoded-word.
+// DecodeHeader decodes decodes an encoded-word.
 //
 // If word is not a valid RFC 2047 encoded-word, word is decoded as raw ISO-8859-1 as a work-around for RMS Express' non-conforming encoding of the Subject header.
 func (d *WordDecoder) DecodeHeader(header string) (string, error) {

--- a/fbb/message.go
+++ b/fbb/message.go
@@ -370,7 +370,7 @@ func readSection(reader *bufio.Reader, readN int) ([]byte, error) {
 	return buf, nil
 }
 
-// Returns true if the given Address is the only receiver of this Message.
+// IsOnlyReceiver returns true if the given Address is the only receiver of this Message.
 func (m *Message) IsOnlyReceiver(addr Address) bool {
 	receivers := m.Receivers()
 	if len(receivers) != 1 {
@@ -425,7 +425,7 @@ func (m *Message) Bytes() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Writes Message to the given Writer in the Winlink Message format.
+// Write writes Message to the given Writer in the Winlink Message format.
 //
 // If the Date header field is not formatted correctly, an error will be returned.
 func (m *Message) Write(w io.Writer) (err error) {
@@ -484,7 +484,7 @@ func (m *Message) String() string {
 	return string(buf.Bytes())
 }
 
-// JSON marshaller for File.
+// MarshalJSON marshaller for File.
 func (f *File) MarshalJSON() ([]byte, error) {
 	b, err := json.Marshal(struct {
 		Name string

--- a/fbb/message_body.go
+++ b/fbb/message_body.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/paulrosania/go-charset/data"
 )
 
-// StringToBytes converts the body into a slice of bytes with the given charset encoding.
+// StringToBody converts the body into a slice of bytes with the given charset encoding.
 //
 // CRLF line break is enforced.
 // Line break are inserted if a line is longer than 1000 characters (including CRLF).

--- a/fbb/proposal.go
+++ b/fbb/proposal.go
@@ -100,12 +100,12 @@ func (p *Proposal) DataIsComplete() bool {
 	return len(p.compressedData) == p.compressedSize
 }
 
-// Returns the uniqe Message ID
+// MID returns the uniqe Message ID
 func (p *Proposal) MID() string {
 	return p.mid
 }
 
-// Returns the title of this proposal
+// Title returns the title of this proposal
 func (p *Proposal) Title() string {
 	return p.title
 }

--- a/fbb/wl2k.go
+++ b/fbb/wl2k.go
@@ -343,7 +343,7 @@ func (s *Session) SetLogger(logger *log.Logger) {
 // Set this session's user agent
 func (s *Session) SetUserAgent(ua UserAgent) { s.ua = ua }
 
-// Get this session's user agent
+// UserAgent gets this session's user agent
 func (s *Session) UserAgent() UserAgent { return s.ua }
 
 func (s *Session) outbound() []*Proposal {

--- a/rigcontrol/hamlib/libhamlib.go
+++ b/rigcontrol/hamlib/libhamlib.go
@@ -132,17 +132,17 @@ func (r *SerialRig) Close() error {
 	return nil
 }
 
-// Returns the Rig's active VFO (for control).
+// CurrentVFO returns the Rig's active VFO (for control).
 func (r *SerialRig) CurrentVFO() VFO {
 	return cVFO{C.RIG_VFO_CURR, r}
 }
 
-// Returns the Rig's A vfo.
+// VFOA returns the Rig's A vfo.
 func (r *SerialRig) VFOA() (VFO, error) {
 	return cVFO{C.RIG_VFO_A, r}, nil
 }
 
-// Returns the Rig's B vfo.
+// VFOB returns the Rig's B vfo.
 func (r *SerialRig) VFOB() (VFO, error) {
 	return cVFO{C.RIG_VFO_B, r}, nil
 }
@@ -177,7 +177,7 @@ func (v cVFO) SetFreq(freq int) error {
 	)
 }
 
-// Gets the dial frequency for this VFO.
+// GetFreq gets the dial frequency for this VFO.
 func (v cVFO) GetFreq() (int, error) {
 	var freq C.freq_t
 	err := codeToError(C.rig_get_freq(&v.r.r, v.v, &freq))
@@ -200,17 +200,17 @@ func (v cVFO) GetMode() (m Mode, pwb int, err error) {
 	return Mode(cm), int(cpwb), err
 }
 
-// Returns the narrow (closest) passband for the given Mode.
+// PassbandNarrow returns the narrow (closest) passband for the given Mode.
 func (r *SerialRig) PassbandNarrow(m Mode) int {
 	return int(C.rig_passband_narrow(&r.r, C.rmode_t(m)))
 }
 
-// Returns the normal (default) passband for the given Mode.
+// PassbandNormal returns the normal (default) passband for the given Mode.
 func (r *SerialRig) PassbandNormal(m Mode) int {
 	return int(C.rig_passband_normal(&r.r, C.rmode_t(m)))
 }
 
-// Returns the wide (default) passband for the given Mode.
+// PassbandWide returns the wide (default) passband for the given Mode.
 func (r *SerialRig) PassbandWide(m Mode) int {
 	return int(C.rig_passband_wide(&r.r, C.rmode_t(m)))
 }

--- a/rigcontrol/hamlib/rigctld.go
+++ b/rigcontrol/hamlib/rigctld.go
@@ -87,10 +87,10 @@ func (r *TCPRig) Close() error {
 	return r.conn.Close()
 }
 
-// Returns the Rig's active VFO (for control).
+// CurrentVFO returns the Rig's active VFO (for control).
 func (r *TCPRig) CurrentVFO() VFO { return &tcpVFO{r, ""} }
 
-// Returns the Rig's VFO A (for control).
+// VFOA returns the Rig's VFO A (for control).
 //
 // ErrNotVFOMode is returned if rigctld is not in VFO mode.
 func (r *TCPRig) VFOA() (VFO, error) {
@@ -103,7 +103,7 @@ func (r *TCPRig) VFOA() (VFO, error) {
 	return &tcpVFO{r, "VFOA"}, nil
 }
 
-// Returns the Rig's VFO B (for control).
+// VFOB returns the Rig's VFO B (for control).
 //
 // ErrNotVFOMode is returned if rigctld is not in VFO mode.
 func (r *TCPRig) VFOB() (VFO, error) {
@@ -124,7 +124,7 @@ func (r *TCPRig) VFOMode() (bool, error) {
 	return resp == "CHKVFO 1", nil
 }
 
-// Gets the dial frequency for this VFO.
+// GetFreq gets the dial frequency for this VFO.
 func (v *tcpVFO) GetFreq() (int, error) {
 	resp, err := v.cmd(`\get_freq`)
 	if err != nil {

--- a/transport/ardop/tnc.go
+++ b/transport/ardop/tnc.go
@@ -367,7 +367,7 @@ func (tnc *TNC) close() {
 	runtime.SetFinalizer(tnc, nil)
 }
 
-// Returns true if channel is clear
+// Busy returns true if channel is clear
 func (tnc *TNC) Busy() bool {
 	return tnc.busy
 }
@@ -377,17 +377,17 @@ func (tnc *TNC) Version() (string, error) {
 	return tnc.getString(cmdVersion)
 }
 
-// Returns the current state of the TNC
+// State returns the current state of the TNC
 func (tnc *TNC) State() State {
 	return tnc.state
 }
 
-// Returns the grid square as reported by the TNC
+// GridSquare returns the grid square as reported by the TNC
 func (tnc *TNC) GridSquare() (string, error) {
 	return tnc.getString(cmdGridSquare)
 }
 
-// Returns mycall as reported by the TNC
+// MyCall returns mycall as reported by the TNC
 func (tnc *TNC) MyCall() (string, error) {
 	return tnc.getString(cmdMyCall)
 }
@@ -412,7 +412,7 @@ func (tnc *TNC) SetARQTimeout(d time.Duration) error {
 	return tnc.set(cmdARQTimeout, int(d/time.Second))
 }
 
-// Gets the ARQ timeout
+// ARQTimeout gets the ARQ timeout
 func (tnc *TNC) ARQTimeout() (time.Duration, error) {
 	seconds, err := tnc.getInt(cmdARQTimeout)
 	return time.Duration(seconds) * time.Second, err
@@ -506,7 +506,7 @@ func (tnc *TNC) SetCodec(state bool) error {
 	return tnc.set(cmdCodec, fmt.Sprintf("%t", state))
 }
 
-// ListenState() returns a StateReceiver which can be used to get notification when the TNC state changes.
+// ListenEnabled returns a StateReceiver which can be used to get notification when the TNC state changes.
 func (tnc *TNC) ListenEnabled() StateReceiver {
 	return tnc.in.ListenState()
 }

--- a/transport/ardop2/tnc.go
+++ b/transport/ardop2/tnc.go
@@ -367,7 +367,7 @@ func (tnc *TNC) close() {
 	runtime.SetFinalizer(tnc, nil)
 }
 
-// Returns true if channel is clear
+// Busy returns true if channel is clear
 func (tnc *TNC) Busy() bool {
 	return tnc.busy
 }
@@ -377,17 +377,17 @@ func (tnc *TNC) Version() (string, error) {
 	return tnc.getString(cmdVersion)
 }
 
-// Returns the current state of the TNC
+// State returns the current state of the TNC
 func (tnc *TNC) State() State {
 	return tnc.state
 }
 
-// Returns the grid square as reported by the TNC
+// GridSquare returns the grid square as reported by the TNC
 func (tnc *TNC) GridSquare() (string, error) {
 	return tnc.getString(cmdGridSquare)
 }
 
-// Returns mycall as reported by the TNC
+// MyCall returns mycall as reported by the TNC
 func (tnc *TNC) MyCall() (string, error) {
 	return tnc.getString(cmdMyCall)
 }
@@ -402,7 +402,7 @@ func (tnc *TNC) SetAutoBreak(on bool) error {
 	return tnc.set(cmdAutoBreak, on)
 }
 
-// Gets the ARQ bandwidth
+// ARQBandwidth gets the ARQ bandwidth
 func (tnc *TNC) ARQBandwidth() (int, error) {
 	return tnc.getInt(cmdARQBW)
 }
@@ -428,7 +428,7 @@ func (tnc *TNC) SetARQTimeout(d time.Duration) error {
 	return tnc.set(cmdARQTimeout, int(d/time.Second))
 }
 
-// Gets the ARQ timeout
+// ARQTimeout gets the ARQ timeout
 func (tnc *TNC) ARQTimeout() (time.Duration, error) {
 	seconds, err := tnc.getInt(cmdARQTimeout)
 	return time.Duration(seconds) * time.Second, err
@@ -522,7 +522,7 @@ func (tnc *TNC) SetCodec(state bool) error {
 	return tnc.set(cmdCodec, fmt.Sprintf("%t", state))
 }
 
-// ListenState() returns a StateReceiver which can be used to get notification when the TNC state changes.
+// ListenEnabled returns a StateReceiver which can be used to get notification when the TNC state changes.
 func (tnc *TNC) ListenEnabled() StateReceiver {
 	return tnc.in.ListenState()
 }

--- a/transport/dial.go
+++ b/transport/dial.go
@@ -36,7 +36,7 @@ var dialers struct {
 	m  map[string]Dialer
 }
 
-// RigisterDialer registers a new scheme and it's Dialer.
+// RegisterDialer registers a new scheme and it's Dialer.
 //
 // The list of registered dialers is used by DialURL.
 func RegisterDialer(scheme string, dialer Dialer) {

--- a/transport/telnet/listen.go
+++ b/transport/telnet/listen.go
@@ -20,7 +20,7 @@ func (conn Conn) RemoteCall() string { return conn.remoteCall }
 
 type listener struct{ net.Listener }
 
-// Starts a new net.Listener listening for incoming connections.
+// Listen starts a new net.Listener listening for incoming connections.
 //
 // The Listener takes care of the special Winlink telnet login.
 func Listen(addr string) (ln net.Listener, err error) {

--- a/transport/winmor/tnc.go
+++ b/transport/winmor/tnc.go
@@ -277,7 +277,7 @@ func (tnc *TNC) Close() error {
 	return nil
 }
 
-// Returns true if channel is clear
+// Busy returns true if channel is clear
 func (tnc *TNC) Busy() bool {
 	return tnc.busy
 }
@@ -287,7 +287,7 @@ func (tnc *TNC) Version() (string, error) {
 	return tnc.getString(cmdVersion)
 }
 
-// Returns the current state of the TNC
+// State returns the current state of the TNC
 func (tnc *TNC) State() State {
 	return tnc.state
 }
@@ -296,12 +296,12 @@ func (tnc *TNC) SetResponseDelay(ms int) error {
 	return tnc.set(cmdResponseDelay, ms)
 }
 
-// Returns the grid square as reported by the TNC
+// GridSquare returns the grid square as reported by the TNC
 func (tnc *TNC) GridSquare() (string, error) {
 	return tnc.getString(cmdGridSquare)
 }
 
-// Returns mycall as reported by the TNC
+// MyCall returns mycall as reported by the TNC
 func (tnc *TNC) MyCall() (string, error) {
 	return tnc.getString(cmdMyCall)
 }
@@ -352,7 +352,7 @@ func (tnc *TNC) SetCodec(state bool) error {
 	return tnc.set(cmdCodec, fmt.Sprintf("%t", state))
 }
 
-// ListenState() returns a StateReceiver which can be used
+// ListenEnabled returns a StateReceiver which can be used
 // to get notification when the TNC state changes.
 func (tnc *TNC) ListenEnabled() StateReceiver {
 	return tnc.in.ListenState()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?