### PR TITLE
Update godoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/la5nta/wl2k-go?status.svg)](http://godoc.org/github.com/la5nta/wl2k-go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/la5nta/wl2k-go)](https://pkg.go.dev/github.com/la5nta/wl2k-go)
 [![Build Status](https://travis-ci.com/la5nta/wl2k-go.svg?branch=master)](https://travis-ci.com/la5nta/wl2k-go)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/j76on3km4vy5vsq0/branch/master?svg=true)](https://ci.appveyor.com/project/martinhpedersen/wl2k-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/la5nta/wl2k-go)](https://goreportcard.com/report/github.com/la5nta/wl2k-go)


### PR DESCRIPTION
https://godoc.org/ is migrating to https://pkg.go.dev/