### PR TITLE
Add capability to send rigctld commands that return more than one result

### DIFF
--- a/rigcontrol/hamlib/common.go
+++ b/rigcontrol/hamlib/common.go
@@ -45,6 +45,29 @@ type VFO interface {
 
 	// Enable (or disable) PTT on this VFO.
 	SetPTT(on bool) error
+
+	// Set VFO modulation mode to 'm' using passband width 'pbw' in Hz, or rig default if 'pbw' is zero.
+	SetMode(m Mode, pbw int) error
+
+	// Get the modulation mode and passband width in Hz that this VFO is set to.
+	GetMode() (m Mode, pwb int, err error)
+}
+
+// ModeToString converts a enum mode as returned from hamlib into a string.
+func ModeToString(m Mode) string {
+	return ModeString[m] // Yes, ignoring unlikely possible error.
+}
+
+// StringToMode converts a string representation of a rig mode into a hamlib enum mode
+// returning a non-nil error if it can't do that.
+func StringToMode(s string) (m Mode, err error) {
+	for mkey := range ModeString {
+		val := ModeString[mkey]
+		if val == s {
+			return mkey, nil
+		}
+	}
+	return 0, fmt.Errorf("Invalid rig mode '%s'", s)
 }
 
 func Open(network, address string) (Rig, error) {

--- a/rigcontrol/hamlib/helpers.c
+++ b/rigcontrol/hamlib/helpers.c
@@ -6,6 +6,8 @@
 // +build libhamlib
 
 #include <hamlib/rig.h>
+extern void rigListCb();
+
 
 void setBaudRate(RIG *r, int rate) {
 	r->state.rigport.parm.serial.rate = rate;

--- a/rigcontrol/hamlib/libhamlib_consts.go
+++ b/rigcontrol/hamlib/libhamlib_consts.go
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 // +build cgo
-// +build libhamlib
 
 package hamlib
 
@@ -35,6 +34,30 @@ const (
 	SAH          = C.RIG_MODE_SAH
 	DSB          = C.RIG_MODE_DSB
 )
+
+var ModeString = map[Mode]string{
+	NoMode:  "NOMODE",
+	AM:      "AM",
+	CW:      "CW",
+	USB:     "USB",
+	LSB:     "LSB",
+	RTTY:    "RTTY",
+	FM:      "FM",
+	WFM:     "WFM",
+	CWR:     "CWR",
+	RTTYR:   "RTTYR",
+	AMS:     "AMS",
+	PKTLSB:  "PKTLSB",
+	PKTUSB:  "PKTUSB",
+	PKTFM:   "PKTFM",
+	ECSSUSB: "ECSSUSB",
+	ECSSLSB: "ECSSLSB",
+	FAX:     "FAX",
+	SAM:     "SAM",
+	SAL:     "SAL",
+	SAH:     "SAH",
+	DSB:     "DSB",
+}
 
 type PowerState int
 


### PR DESCRIPTION
The existing code assumes that all rigctld commands return a single result, like get_freq but get_mode and others return two or more. rigctld has an awkward API that does not tell you when it has sent the last result so you just have to know how many results you are expecting and read that many lines. The results are packed into an array of string so the internal unexported functions needed to be altered slightly but the exported functions are backward compatible and also compatible with the libhamlib wrapper.

I needed the enum for the rig modulation modes so I had to make the rigctld depend on the C .h file. That could be fixed if that dependency is unwanted.

There is a "new" protocol for rigctld that seemed to solved the problem above and I coded for that until I found out that not all the rigctld commands actually implement the new protocol! When that happens the code could be made more compact and less messy.

The purpose of this change is to enable a patch that allows the setting of the rig's modulation mode, which is not possible without it.