### PR TITLE
Deprecate default directory methods for app and mailbox

### DIFF
--- a/mailbox/syncdir.go
+++ b/mailbox/syncdir.go
@@ -169,6 +169,7 @@ func (h *DirHandler) GetOutbound(fws ...fbb.Address) []*fbb.Message {
 	return deliver
 }
 
+// Deprecated: implementers should choose their own directories
 func DefaultMailboxPath() (string, error) {
 	appdir, err := DefaultAppDir()
 	if err != nil {
@@ -177,6 +178,7 @@ func DefaultMailboxPath() (string, error) {
 	return path.Join(appdir, "mailbox"), nil
 }
 
+// Deprecated: implementers should choose their own directories
 func DefaultAppDir() (string, error) {
 	usr, err := user.Current()
 	if err != nil {


### PR DESCRIPTION
I'm looking at this as part of https://github.com/la5nta/pat/issues/216

At first, I thought I would add separate methods for config, data and state and only deprecate `DefaultAppDir`. However, recommending default directories here seems really tangential to the rest of the code.

Also, having defaults here encourages all apps built on wl2k-go to share data directories. If there were another hypothetical wl2k-go client besides Pat, would we really want them to share directory structures?