### PR TITLE
serial-tnc: Add serial_baud url parameter

### DIFF
--- a/transport/ax25/ax25.go
+++ b/transport/ax25/ax25.go
@@ -30,6 +30,11 @@ import (
 	"github.com/la5nta/wl2k-go/transport"
 )
 
+const (
+	// DefaultSerialBaud is the default serial_baud value of the serial-tnc scheme.
+	DefaultSerialBaud = 9600
+)
+
 const _NETWORK = "AX.25"
 
 var DefaultDialer = &Dialer{Timeout: 45 * time.Second}
@@ -124,18 +129,22 @@ func (d Dialer) DialURL(url *transport.URL) (net.Conn, error) {
 	case "ax25":
 		return DialAX25Timeout(url.Host, url.User.Username(), target, d.Timeout)
 	case "serial-tnc":
-		//TODO: This is some badly designed legacy stuff. Need to re-think the whole
-		//serial-tnc scheme. See issue #34.
-		baudrate := Baudrate(1200)
+		// TODO: This is some badly designed legacy stuff. Need to re-think the whole
+		// serial-tnc scheme. See issue #34.
+		hbaud := HBaud(1200)
 		if i, _ := strconv.Atoi(url.Params.Get("hbaud")); i > 0 {
-			baudrate = Baudrate(i)
+			hbaud = HBaud(i)
+		}
+		serialBaud := DefaultSerialBaud
+		if i, _ := strconv.Atoi(url.Params.Get("serial_baud")); i > 0 {
+			serialBaud = i
 		}
 
 		return DialKenwood(
 			url.Host,
 			url.User.Username(),
 			target,
-			NewConfig(baudrate),
+			NewConfig(hbaud, serialBaud),
 			nil,
 		)
 	default:
@@ -161,5 +170,4 @@ func (a Address) String() string {
 	} else {
 		return a.Call
 	}
-
 }

--- a/transport/ax25/kenwood.go
+++ b/transport/ax25/kenwood.go
@@ -51,7 +51,7 @@ func DialKenwood(dev, mycall, targetcall string, config Config, logger *log.Logg
 		}
 		conn.Conn.ReadWriteCloser = c
 	} else {
-		s, err := serial.Open(dev, serial.WithBaudrate(9600))
+		s, err := serial.Open(dev, serial.WithBaudrate(config.SerialBaud))
 		if err != nil {
 			return conn, err
 		} else {

--- a/transport/ax25/tnc.go
+++ b/transport/ax25/tnc.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	B9600 Baudrate = 9600
-	B1200          = 1200
+	B9600 HBaud = 9600
+	B1200       = 1200
 )
 
 const (
@@ -29,10 +29,11 @@ type tncAddr struct {
 func (a tncAddr) Digis() []Address { return a.digis }
 func (a tncAddr) Address() Address { return a.address }
 
-type Baudrate int
+type HBaud int
 
 type Config struct {
-	HBaud        Baudrate      // Baudrate for packet channel [1200/9600].
+	HBaud        HBaud         // Baudrate for packet channel [1200/9600].
+	SerialBaud   int           // Baudrate for the serial port.
 	TXDelay      time.Duration // Time delay between PTT ON and start of transmission [(0 - 120) * 10ms].
 	PacketLength uint8         // Maximum length of the data portion of a packet [0 - 255 bytes].
 	Persist      uint8         // Parameter to calculate probability for the PERSIST/SLOTTIME method [0-255].
@@ -42,11 +43,12 @@ type Config struct {
 	ResponseTime time.Duration // ACK-packet transmission delay [0-255 * 100ms].
 }
 
-func NewConfig(baud Baudrate) Config {
-	switch baud {
+func NewConfig(hbaud HBaud, serialBaud int) Config {
+	switch hbaud {
 	case B1200:
 		return Config{
 			HBaud:        B1200,
+			SerialBaud:   serialBaud,
 			TXDelay:      120 * time.Millisecond,
 			PacketLength: 128,
 			Persist:      128,
@@ -58,6 +60,7 @@ func NewConfig(baud Baudrate) Config {
 	case B9600:
 		return Config{
 			HBaud:        B9600,
+			SerialBaud:   serialBaud,
 			TXDelay:      100 * time.Millisecond,
 			PacketLength: 255,
 			Persist:      190,
@@ -70,7 +73,7 @@ func NewConfig(baud Baudrate) Config {
 	return Config{}
 }
 
-//TODO:review and improve
+// TODO:review and improve
 func tncAddrFromString(str string) tncAddr {
 	parts := strings.Split(str, " ")
 	addr := tncAddr{


### PR DESCRIPTION
For specifying the serial baudrate for the TNC.

Ref issue la5nta/pat#279