### PR TITLE
Use all upper case for env variables

### DIFF
--- a/transport/ardop/ardop.go
+++ b/transport/ardop/ardop.go
@@ -98,5 +98,5 @@ func strToState(str string) (State, bool) {
 }
 
 func debugEnabled() bool {
-	return os.Getenv("ardop_debug") != ""
+	return os.Getenv("ARDOP_DEBUG") != ""
 }

--- a/transport/ardop2/ardop.go
+++ b/transport/ardop2/ardop.go
@@ -67,5 +67,5 @@ func strToState(str string) (State, bool) {
 }
 
 func debugEnabled() bool {
-	return os.Getenv("ardop_debug") != ""
+	return os.Getenv("ARDOP_DEBUG") != ""
 }

--- a/transport/winmor/winmor.go
+++ b/transport/winmor/winmor.go
@@ -62,5 +62,5 @@ func strToState(str string) (State, bool) {
 }
 
 func debugEnabled() bool {
-	return os.Getenv("winmor_debug") != ""
+	return os.Getenv("WINMOR_DEBUG") != ""
 }


### PR DESCRIPTION
I didn't realize that environment variables are case sensitive until now.

This changes the debug environment variables to be all upper case.