### PR TITLE
Add `bw` query param parsing to ARDOP

### DIFF
--- a/transport/ardop/ardop_test.go
+++ b/transport/ardop/ardop_test.go
@@ -1,0 +1,88 @@
+package ardop
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBandwidth(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Bandwidth
+		wantErr bool
+	}{
+		{
+			in:      "200",
+			want:    Bandwidth200Max,
+			wantErr: false,
+		}, {
+			in:      "500",
+			want:    Bandwidth500Max,
+			wantErr: false,
+		}, {
+			in:      "1000",
+			want:    Bandwidth1000Max,
+			wantErr: false,
+		}, {
+			in:      "2000",
+			want:    Bandwidth2000Max,
+			wantErr: false,
+		}, {
+			in:      "200MAX",
+			want:    Bandwidth200Max,
+			wantErr: false,
+		}, {
+			in:      "500MAX",
+			want:    Bandwidth500Max,
+			wantErr: false,
+		}, {
+			in:      "1000MAX",
+			want:    Bandwidth1000Max,
+			wantErr: false,
+		}, {
+			in:      "2000MAX",
+			want:    Bandwidth2000Max,
+			wantErr: false,
+		}, {
+			in:      "200FORCED",
+			want:    Bandwidth200Forced,
+			wantErr: false,
+		}, {
+			in:      "500FORCED",
+			want:    Bandwidth500Forced,
+			wantErr: false,
+		}, {
+			in:      "1000FORCED",
+			want:    Bandwidth1000Forced,
+			wantErr: false,
+		}, {
+			in:      "2000FORCED",
+			want:    Bandwidth2000Forced,
+			wantErr: false,
+		}, {
+			in:      "2000INVALID",
+			want:    Bandwidth{},
+			wantErr: true,
+		}, {
+			in:      "5000",
+			want:    Bandwidth{},
+			wantErr: true,
+		}, {
+			in:      "FORCED",
+			want:    Bandwidth{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := StrToBandwidth(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StrToBandwidth() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StrToBandwidth() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/transport/ardop/ardop_test.go
+++ b/transport/ardop/ardop_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestParseBandwidth(t *testing.T) {
+func TestStrToBandwidth(t *testing.T) {
 	tests := []struct {
 		in      string
 		want    Bandwidth

--- a/transport/ardop/dial.go
+++ b/transport/ardop/dial.go
@@ -17,6 +17,18 @@ func (tnc *TNC) DialURL(url *transport.URL) (net.Conn, error) {
 		return nil, transport.ErrUnsupportedScheme
 	}
 
+	// Set bandwidth from the URL
+	bw := url.Params.Get("bw")
+	if bw != "" {
+		bandwidth, err := StrToBandwidth(bw)
+		if err != nil {
+			return nil, err
+		}
+		if err = tnc.SetARQBandwidth(bandwidth); err != nil {
+			return nil, err
+		}
+	}
+
 	return tnc.Dial(url.Target)
 }
 


### PR DESCRIPTION
This will help implement https://github.com/la5nta/pat/issues/120. This generally wants the `bw` query parameter to match the string sent to the ARDOP TNC, e.g. `500MAX` or `2000FORCED`, but relaxes the API a bit by assuming `MAX` if no word is sent with the bandwidth value.