### PR TITLE
ardop: Accept bandwidth (`bw`) dial parameter

### DIFF
--- a/fbb/wl2k.go
+++ b/fbb/wl2k.go
@@ -217,6 +217,7 @@ func (s *Session) Exchange(conn net.Conn) (stats TrafficStats, err error) {
 	// The given conn should always be closed after returning from this method.
 	// If an error occurred, echo it to the remote.
 	defer func() {
+		defer conn.Close()
 		switch {
 		case err == nil:
 			// Success :-)
@@ -233,7 +234,6 @@ func (s *Session) Exchange(conn net.Conn) (stats TrafficStats, err error) {
 			// Echo the error to the remote peer and disconnect.
 			conn.SetDeadline(time.Now().Add(time.Minute))
 			fmt.Fprintf(conn, "*** %s\r\n", err)
-			conn.Close()
 		}
 	}()
 

--- a/transport/ardop/ardop.go
+++ b/transport/ardop/ardop.go
@@ -45,6 +45,7 @@ var (
 	ErrConnectTimeout       = errors.New("Connect timeout")
 	ErrChecksumMismatch     = errors.New("Control protocol checksum mismatch")
 	ErrTNCClosed            = errors.New("TNC closed")
+	ErrUnsupportedBandwidth = errors.New("Unsupported ARQ bandwidth")
 )
 
 // Bandwidth definitions of all supported ARQ bandwidths.
@@ -80,6 +81,37 @@ func (bw Bandwidth) String() string {
 
 // IsZero returns true if bw is it's zero value.
 func (bw Bandwidth) IsZero() bool { return bw.Max == 0 }
+
+// BandwidthFromString returns a Bandwidth representation of the given string.
+//
+// The string must be a valid ARDOP ARQ bandwidth string (e.g. "2000MAX", "2000FORCED").
+// The MAX/FORCED suffix may be omitted. Defaults to MAX.
+func BandwidthFromString(str string) (Bandwidth, error) {
+	//  Default to MAX if MAX/FORCED is not given.
+	if strings.HasSuffix(str, "0") {
+		str += "MAX"
+	}
+	for _, bw := range Bandwidths() {
+		if bw.String() == str {
+			return bw, nil
+		}
+	}
+	return Bandwidth{}, ErrUnsupportedBandwidth
+}
+
+// Bandwidths returns a list of all ARDOP ARQ bandwidths.
+func Bandwidths() []Bandwidth {
+	return []Bandwidth{
+		Bandwidth200Max,
+		Bandwidth500Max,
+		Bandwidth1000Max,
+		Bandwidth2000Max,
+		Bandwidth200Forced,
+		Bandwidth500Forced,
+		Bandwidth1000Forced,
+		Bandwidth2000Forced,
+	}
+}
 
 var stateMap = map[string]State{
 	"":        Unknown,

--- a/transport/ardop/command.go
+++ b/transport/ardop/command.go
@@ -138,7 +138,7 @@ func parseCtrlMsg(str string) ctrlMsg {
 	case cmdAbort, cmdDisconnect, cmdClose, cmdDisconnected, cmdCRCFault, cmdPending, cmdCancelPending, cmdSendID:
 
 	// (echo-back only)
-	case cmdInitialize, cmdARQCall, cmdARQBW, cmdProtocolMode:
+	case cmdInitialize, cmdARQCall, cmdProtocolMode:
 
 	// State
 	case cmdNewState, cmdState:
@@ -146,7 +146,7 @@ func parseCtrlMsg(str string) ctrlMsg {
 
 	// string
 	case cmdFault, cmdMyCall, cmdGridSquare, cmdCapture,
-		cmdPlayback, cmdVersion, cmdTarget, cmdStatus:
+		cmdPlayback, cmdVersion, cmdTarget, cmdStatus, cmdARQBW:
 		msg.value = parts[1]
 
 	// []string (space separated)

--- a/transport/ardop/command_test.go
+++ b/transport/ardop/command_test.go
@@ -11,21 +11,22 @@ import (
 
 func TestParse(t *testing.T) {
 	tests := map[string]ctrlMsg{
-		"NEWSTATE DISC":                     ctrlMsg{cmdNewState, Disconnected},
-		"PTT True":                          ctrlMsg{cmdPTT, true},
-		"PTT False":                         ctrlMsg{cmdPTT, false},
-		"PTT trUE":                          ctrlMsg{cmdPTT, true},
-		"CODEC True":                        ctrlMsg{cmdCodec, true},
-		"foobar baz":                        ctrlMsg{command("FOOBAR"), nil},
-		"DISCONNECTED":                      ctrlMsg{cmdDisconnected, nil},
-		"FAULT 5/Error in the application.": ctrlMsg{cmdFault, "5/Error in the application."},
-		"BUFFER 300":                        ctrlMsg{cmdBuffer, 300},
-		"MYCALL LA5NTA":                     ctrlMsg{cmdMyCall, "LA5NTA"},
-		"GRIDSQUARE JP20QH":                 ctrlMsg{cmdGridSquare, "JP20QH"},
-		"MYAUX LA5NTA,LE3OF":                ctrlMsg{cmdMyAux, []string{"LA5NTA", "LE3OF"}},
-		"MYAUX LA5NTA, LE3OF":               ctrlMsg{cmdMyAux, []string{"LA5NTA", "LE3OF"}},
-		"VERSION 1.4.7.0":                   ctrlMsg{cmdVersion, "1.4.7.0"},
-		"FREQUENCY 14096400":                ctrlMsg{cmdFrequency, 14096400},
+		"NEWSTATE DISC":                     {cmdNewState, Disconnected},
+		"PTT True":                          {cmdPTT, true},
+		"PTT False":                         {cmdPTT, false},
+		"PTT trUE":                          {cmdPTT, true},
+		"CODEC True":                        {cmdCodec, true},
+		"foobar baz":                        {command("FOOBAR"), nil},
+		"DISCONNECTED":                      {cmdDisconnected, nil},
+		"FAULT 5/Error in the application.": {cmdFault, "5/Error in the application."},
+		"BUFFER 300":                        {cmdBuffer, 300},
+		"MYCALL LA5NTA":                     {cmdMyCall, "LA5NTA"},
+		"GRIDSQUARE JP20QH":                 {cmdGridSquare, "JP20QH"},
+		"MYAUX LA5NTA,LE3OF":                {cmdMyAux, []string{"LA5NTA", "LE3OF"}},
+		"MYAUX LA5NTA, LE3OF":               {cmdMyAux, []string{"LA5NTA", "LE3OF"}},
+		"VERSION 1.4.7.0":                   {cmdVersion, "1.4.7.0"},
+		"FREQUENCY 14096400":                {cmdFrequency, 14096400},
+		"ARQBW 200MAX":                      {cmdARQBW, "200MAX"},
 	}
 	for input, expected := range tests {
 		got := parseCtrlMsg(input)

--- a/transport/ardop/dial.go
+++ b/transport/ardop/dial.go
@@ -11,26 +11,61 @@ import (
 	"github.com/la5nta/wl2k-go/transport"
 )
 
-// DialURL dials ardop:// URLs
+// DialURL dials ardop:// URLs.
+//
+// Parameter bw can be used to set the ARQ bandwidth for this connection. See DialBandwidth for details.
 func (tnc *TNC) DialURL(url *transport.URL) (net.Conn, error) {
 	if url.Scheme != "ardop" {
 		return nil, transport.ErrUnsupportedScheme
 	}
-
-	return tnc.Dial(url.Target)
+	bwStr := url.Params.Get("bw")
+	if bwStr == "" {
+		return tnc.Dial(url.Target)
+	}
+	bw, err := BandwidthFromString(bwStr)
+	if err != nil {
+		return nil, err
+	}
+	return tnc.DialBandwidth(url.Target, bw)
 }
 
+// Dial dials a ARQ connection.
 func (tnc *TNC) Dial(targetcall string) (net.Conn, error) {
+	return tnc.DialBandwidth(targetcall, Bandwidth{})
+}
+
+// DialBandwidth dials a ARQ connection after setting the given ARQ bandwidth temporarily.
+//
+// The ARQ bandwidth setting is reverted on any Dial error and when calling conn.Close().
+func (tnc *TNC) DialBandwidth(targetcall string, bw Bandwidth) (net.Conn, error) {
 	if tnc.closed {
 		return nil, ErrTNCClosed
 	}
 
+	var defers []func() error
+	if !bw.IsZero() {
+		currentBw, err := tnc.ARQBandwidth()
+		if err != nil {
+			return nil, err
+		}
+		if err := tnc.SetARQBandwidth(bw); err != nil {
+			return nil, err
+		}
+		defers = append(defers, func() error { return tnc.SetARQBandwidth(currentBw) })
+	}
+
 	if err := tnc.arqCall(targetcall, 10); err != nil {
+		for _, fn := range defers {
+			_ = fn()
+		}
 		return nil, err
 	}
 
 	mycall, err := tnc.MyCall()
 	if err != nil {
+		for _, fn := range defers {
+			_ = fn()
+		}
 		return nil, fmt.Errorf("Error when getting mycall: %s", err)
 	}
 
@@ -43,6 +78,7 @@ func (tnc *TNC) Dial(targetcall string) (net.Conn, error) {
 		dataIn:     tnc.dataIn,
 		eofChan:    make(chan struct{}),
 		isTCP:      tnc.isTCP,
+		onClose:    defers,
 	}
 
 	return tnc.data, nil

--- a/transport/ardop/tnc.go
+++ b/transport/ardop/tnc.go
@@ -302,7 +302,7 @@ func (tnc *TNC) runControlLoop() error {
 				}
 
 				if err != nil {
-					panic(err) //FIXME
+					panic(err) // FIXME
 				}
 			}
 		}
@@ -405,6 +405,18 @@ func (tnc *TNC) SetAutoBreak(on bool) error {
 // Sets the ARQ bandwidth
 func (tnc *TNC) SetARQBandwidth(bw Bandwidth) error {
 	return tnc.set(cmdARQBW, bw)
+}
+
+func (tnc *TNC) ARQBandwidth() (Bandwidth, error) {
+	str, err := tnc.getString(cmdARQBW)
+	if err != nil {
+		return Bandwidth{}, err
+	}
+	bw, err := BandwidthFromString(str)
+	if err != nil {
+		return Bandwidth{}, fmt.Errorf("invalid ARQBW response: %w", err)
+	}
+	return bw, nil
 }
 
 // Sets the ARQ timeout


### PR DESCRIPTION
An alternative to #73 which reverts the ARQ bandwidth setting on dial error or after the connection is closed.

Felt like I had to pitch in on this one @xylo04, since my request complicated the task quite a bit.

Let me know what you think 🙂 