### PR TITLE
Context oriented DialURL for dial cancellation

### DIFF
--- a/transport/ardop/dial.go
+++ b/transport/ardop/dial.go
@@ -31,6 +31,9 @@ func (tnc *TNC) DialURL(url *transport.URL) (net.Conn, error) {
 }
 
 // DialURLContext dials ardop:// URLs with cancellation support. See DialURL.
+//
+// If the context is cancelled while dialing, the connection may be closed gracefully before returning an error.
+// Use Abort() for immediate cancellation of a dial operation.
 func (tnc *TNC) DialURLContext(ctx context.Context, url *transport.URL) (net.Conn, error) {
 	var (
 		conn net.Conn

--- a/transport/ardop/tnc.go
+++ b/transport/ardop/tnc.go
@@ -557,6 +557,9 @@ func (tnc *TNC) Disconnect() error {
 		if msg.cmd == cmdDisconnected {
 			return nil
 		}
+		if tnc.Idle() {
+			return nil
+		}
 	}
 	return ErrTNCClosed
 }

--- a/transport/ax25/ax25_other.go
+++ b/transport/ax25/ax25_other.go
@@ -2,11 +2,13 @@
 // Use of this source code is governed by the MIT-license that can be
 // found in the LICENSE file.
 
+//go:build !libax25
 // +build !libax25
 
 package ax25
 
 import (
+	"context"
 	"errors"
 	"net"
 	"time"
@@ -23,5 +25,9 @@ func DialAX25Timeout(axPort, mycall, targetcall string, timeout time.Duration) (
 }
 
 func DialAX25(axPort, mycall, targetcall string) (*Conn, error) {
-	return DialAX25Timeout(axPort, mycall, targetcall, 0)
+	return nil, ErrNoLibax25
+}
+
+func DialAX25Context(ctx context.Context, axPort, mycall, targetcall string) (*Conn, error) {
+	return nil, ErrNoLibax25
 }

--- a/transport/interfaces.go
+++ b/transport/interfaces.go
@@ -43,6 +43,7 @@ type Dialer interface {
 type ContextDialer interface {
 	// DiaulURLContext dials a connection.
 	//
-	// If the given context is cancelled before the connection is made, the operation should be aborted and an error returned.
+	// If the given context is cancelled before the connection is made, the operation is aborted and an error returned.
+	// Once successfully connected, any expiration of the context will not affect the connection.
 	DialURLContext(ctx context.Context, url *URL) (net.Conn, error)
 }

--- a/transport/interfaces.go
+++ b/transport/interfaces.go
@@ -4,7 +4,10 @@
 
 package transport
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 type Flusher interface {
 	// Flush flushes the transmit buffers of the underlying modem.
@@ -34,4 +37,12 @@ type PTTController interface {
 // Dialer is implemented by transports that supports dialing a transport.URL.
 type Dialer interface {
 	DialURL(url *URL) (net.Conn, error)
+}
+
+// ContextDialer is implemented by transports that supports dialing with cancellation.
+type ContextDialer interface {
+	// DiaulURLContext dials a connection.
+	//
+	// If the given context is cancelled before the connection is made, the operation should be aborted and an error returned.
+	DialURLContext(ctx context.Context, url *URL) (net.Conn, error)
 }


### PR DESCRIPTION
DialURLContext extends DialURL's functionality by accepting a context.Context for cancelling the dial operation. It is implemented backwards compatible, so we don't have to update all transports to support this.

It was inspired by the [net.DialContext](https://pkg.go.dev/net#Dialer.DialContext) from the standard library, which supports the same use cases.

I'm also working on incorporating this into Pat, which will enable dial cancellation for stateless transports like `telnet` and `ax25`.