### PR TITLE
Add package agwpe

### DIFF
--- a/transport/ax25/agwpe/address.go
+++ b/transport/ax25/agwpe/address.go
@@ -1,0 +1,17 @@
+package agwpe
+
+import "strings"
+
+type addr struct {
+	dest  string
+	digis []string
+}
+
+func (a addr) Network() string { return "AX.25" }
+
+func (a addr) String() string {
+	if len(a.digis) == 0 {
+		return a.dest
+	}
+	return a.dest + " via " + strings.Join(a.digis, " ")
+}

--- a/transport/ax25/agwpe/agwpe.go
+++ b/transport/ax25/agwpe/agwpe.go
@@ -1,0 +1,116 @@
+package agwpe
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"time"
+)
+
+var (
+	ErrTNCClosed  = errors.New("TNC closed")
+	ErrPortClosed = errors.New("port closed")
+)
+
+type TNC struct {
+	conn  net.Conn
+	demux *demux
+}
+
+func newTNC(conn net.Conn) *TNC {
+	t := &TNC{
+		conn:  conn,
+		demux: newDemux(),
+	}
+	go t.run()
+	return t
+}
+
+func (t *TNC) run() {
+	defer debugf("TNC run() exited")
+	defer t.Close()
+	for {
+		var f frame
+		if err := t.read(&f); err != nil {
+			debugf("read failed: %v", err)
+			return
+		}
+		if !t.demux.Enqueue(f) {
+			return
+		}
+	}
+}
+
+func OpenTCP(addr string) (*TNC, error) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return newTNC(conn), nil
+}
+
+func (t *TNC) Ping() error { _, err := t.Version(); return err }
+
+func (t *TNC) Version() (string, error) {
+	resp := t.demux.NextFrame(kindVersionNumber)
+	t.write(versionNumberFrame())
+	select {
+	case <-time.After(3 * time.Second):
+		return "", fmt.Errorf("response timeout")
+	case f, ok := <-resp:
+		if !ok {
+			return "", ErrTNCClosed
+		}
+		if len(f.Data) != 8 {
+			return "", fmt.Errorf("'%c' frame with invalid data length", f.DataKind)
+		}
+		var v struct{ Major, _, Minor, _ uint16 }
+		binary.Read(bytes.NewReader(f.Data), binary.LittleEndian, &v)
+		return fmt.Sprintf("%d.%d", v.Major, v.Minor), nil
+	}
+}
+
+func (t *TNC) Close() error {
+	t.demux.Close()
+	return t.conn.Close()
+}
+
+func (t *TNC) RegisterPort(port int, mycall string) (*Port, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	p := newPort(t, uint8(port), mycall)
+	if err := p.register(ctx); err != nil {
+		t.Close()
+		return nil, err
+	}
+	return p, nil
+}
+
+func (t *TNC) write(f frame) error {
+	_, err := f.WriteTo(t.conn)
+	if err == nil {
+		debugf("-> %v", f)
+	}
+	return err
+}
+
+func (t *TNC) read(f *frame) error {
+	_, err := f.ReadFrom(t.conn)
+	if err == nil {
+		debugf("<- %v", *f)
+	}
+	return err
+}
+
+func debugf(s string, v ...interface{}) {
+	if t, _ := strconv.ParseBool(os.Getenv("AGWPE_DEBUG")); !t {
+		return
+	}
+	log.Printf(s, v...)
+}

--- a/transport/ax25/agwpe/agwpe.go
+++ b/transport/ax25/agwpe/agwpe.go
@@ -94,7 +94,7 @@ func (t *TNC) RegisterPort(port int, mycall string) (*Port, error) {
 
 func (t *TNC) write(f frame) error {
 	_, err := f.WriteTo(t.conn)
-	if err == nil {
+	if err == nil && f.DataKind != kindOutstandingFramesForConn {
 		debugf("-> %v", f)
 	}
 	return err
@@ -102,7 +102,7 @@ func (t *TNC) write(f frame) error {
 
 func (t *TNC) read(f *frame) error {
 	_, err := f.ReadFrom(t.conn)
-	if err == nil {
+	if err == nil && f.DataKind != kindOutstandingFramesForConn {
 		debugf("<- %v", *f)
 	}
 	return err

--- a/transport/ax25/agwpe/conn.go
+++ b/transport/ax25/agwpe/conn.go
@@ -1,0 +1,149 @@
+package agwpe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+type Conn struct {
+	p          *Port
+	demux      *demux
+	dataFrames <-chan frame
+
+	srcCall, dstCall string
+	via              []string
+
+	readDeadline, writeDeadline time.Time
+}
+
+func newConn(p *Port, dstCall string, via ...string) *Conn {
+	demux := p.demux.Chain(framesFilter{call: callsignFromString(dstCall)})
+	disconnect := demux.NextFrame(kindDisconnect)
+	dataFrames, cancelData := demux.Frames(10, framesFilter{kinds: []kind{kindConnectedData}})
+	go func() {
+		<-disconnect
+		debugf("disconnect frame received - connection teardown...")
+		cancelData()
+		demux.Close()
+	}()
+	return &Conn{
+		p:          p,
+		demux:      demux,
+		srcCall:    p.mycall,
+		dstCall:    dstCall,
+		via:        via,
+		dataFrames: dataFrames,
+	}
+}
+
+func (c *Conn) numOutstandingFrames() (int, error) {
+	// TODO: From Direwolf 1.5 we could get connection specific value using the 'Y' frame.
+	return c.p.numOutstandingFrames()
+}
+
+// Flush implements the transport.Flusher interface.
+func (c *Conn) Flush() error {
+	debugf("flushing...")
+	for {
+		n, err := c.p.numOutstandingFrames()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			debugf("flushed")
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (c *Conn) Write(p []byte) (int, error) {
+	// TODO: c.writeDeadline
+	cp := make([]byte, len(p))
+	copy(cp, p)
+	f := connectedDataFrame(c.p.port, c.srcCall, c.dstCall, p)
+	if err := c.p.write(f); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *Conn) Read(p []byte) (int, error) {
+	ctx := context.Background()
+	if !c.readDeadline.IsZero() {
+		var cancel func()
+		ctx, cancel = context.WithDeadline(ctx, c.readDeadline)
+		defer cancel()
+	}
+	select {
+	case <-ctx.Done():
+		// TODO (read timeout error)
+		return 0, ctx.Err()
+	case f, ok := <-c.dataFrames:
+		if !ok {
+			return 0, io.EOF
+		}
+		if len(p) < len(f.Data) {
+			panic("buffer overflow")
+		}
+		copy(p, f.Data)
+		return len(f.Data), nil
+	}
+}
+
+func (c *Conn) Close() error {
+	if c.demux.isClosed() {
+		return nil
+	}
+	c.Flush()
+	defer c.demux.Close()
+	return c.p.write(disconnectFrame(c.srcCall, c.dstCall, c.p.port))
+	// TODO: Block until disconnect ack
+}
+
+func (c *Conn) connect(ctx context.Context) error {
+	connectFrame := func() frame {
+		if len(c.via) > 0 {
+			return connectViaFrame(c.srcCall, c.dstCall, c.p.port, c.via)
+		}
+		return connectFrame(c.srcCall, c.dstCall, c.p.port)
+	}
+
+	ack := c.demux.NextFrame(kindConnect, kindDisconnect)
+	if err := c.p.write(connectFrame()); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		c.p.write(disconnectFrame(c.srcCall, c.dstCall, c.p.port))
+		return ctx.Err()
+	case f, ok := <-ack:
+		if !ok {
+			return ErrPortClosed
+		}
+		switch f.DataKind {
+		case kindConnect:
+			if !bytes.HasPrefix(f.Data, []byte("*** CONNECTED With ")) {
+				c.p.write(disconnectFrame(c.srcCall, c.dstCall, c.p.port))
+				return fmt.Errorf("connect precondition failed")
+			}
+			return nil
+		case kindDisconnect:
+			return fmt.Errorf("%s", strings.TrimSpace(strFromBytes(f.Data)))
+		default:
+			panic("impossible")
+		}
+	}
+}
+
+func (c *Conn) LocalAddr() net.Addr  { return addr{dest: c.srcCall} }
+func (c *Conn) RemoteAddr() net.Addr { return addr{dest: c.dstCall, digis: c.via} }
+
+func (c *Conn) SetWriteDeadline(t time.Time) error { c.writeDeadline = t; return nil }
+func (c *Conn) SetReadDeadline(t time.Time) error  { c.readDeadline = t; return nil }
+func (c *Conn) SetDeadline(t time.Time) error      { c.readDeadline, c.writeDeadline = t, t; return nil }

--- a/transport/ax25/agwpe/demux.go
+++ b/transport/ax25/agwpe/demux.go
@@ -1,0 +1,181 @@
+package agwpe
+
+import (
+	"sync"
+)
+
+type framesFilter struct {
+	kinds []kind
+	port  *uint8
+	call  callsign // to OR from
+	to    callsign
+}
+
+type framesReq struct {
+	framesFilter
+	once bool
+	done chan struct{}
+	resp chan frame
+}
+
+func newFramesReq(bufSize int, filter framesFilter) framesReq {
+	return framesReq{
+		framesFilter: filter,
+		done:         make(chan struct{}),
+		resp:         make(chan frame, bufSize),
+	}
+}
+
+func (r framesReq) Cancel() { close(r.done) }
+
+func (f framesFilter) Want(frame frame) bool {
+	switch {
+	case f.port != nil && *f.port != frame.Port:
+		return false
+	case f.call != (callsign{}) && !(f.call == frame.From || f.call == frame.To):
+		return false
+	case f.to != (callsign{}) && !(f.to == frame.To):
+		return false
+	}
+	if len(f.kinds) == 0 {
+		return true
+	}
+	for _, k := range f.kinds {
+		if frame.DataKind == k {
+			return true
+		}
+	}
+	return false
+}
+
+type demux struct {
+	requests chan framesReq
+
+	mu     sync.Mutex
+	closed bool
+	in     chan frame
+}
+
+func newDemux() *demux {
+	d := demux{
+		in:       make(chan frame, 1),
+		requests: make(chan framesReq),
+	}
+	go d.run()
+	return &d
+}
+
+func (d *demux) isClosed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closed
+}
+
+func (d *demux) Chain(filter framesFilter) *demux {
+	if d.isClosed() {
+		panic("demux closed")
+	}
+	next := newDemux()
+	filtered, cancel := d.Frames(0, filter)
+	go func() {
+		defer cancel()
+		defer next.Close()
+		defer debugf("chain exited")
+		for {
+			f, ok := <-filtered
+			if !ok {
+				return
+			}
+			if !next.Enqueue(f) {
+				return
+			}
+		}
+	}()
+	return next
+}
+
+func (d *demux) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	close(d.in)
+	d.closed = true
+	return nil
+}
+
+func (d *demux) Enqueue(f frame) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return false
+	}
+	select {
+	case d.in <- f:
+	default:
+		debugf("port buffer full - dropping frame")
+	}
+	return true
+}
+
+func (d *demux) NextFrame(kinds ...kind) <-chan frame {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	req := newFramesReq(1, framesFilter{kinds: kinds})
+	req.once = true
+	d.requests <- req
+	return req.resp
+}
+
+func (d *demux) Frames(bufSize int, filter framesFilter) (filtered <-chan frame, cancel func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil, func() {}
+	}
+	req := newFramesReq(bufSize, filter)
+	req.once = false
+	d.requests <- req
+	return req.resp, req.Cancel
+}
+
+func (d *demux) run() {
+	defer debugf("demux exited")
+	var clients []framesReq
+	for {
+		select {
+		case c := <-d.requests:
+			clients = append(clients, c)
+		case f, ok := <-d.in:
+			if !ok {
+				debugf("demux closing (%d clients)...", len(clients))
+				for _, c := range clients {
+					close(c.resp)
+				}
+				clients = nil
+				return
+			}
+			// Match against active clients
+			for i := 0; i < len(clients); i++ {
+				c := clients[i]
+				if !c.Want(f) {
+					continue
+				}
+				select {
+				case c.resp <- f:
+					if !c.once {
+						continue
+					}
+				case <-c.done:
+				}
+				close(c.resp)
+				clients = append(clients[:i], clients[i+1:]...)
+				i--
+			}
+		}
+	}
+}

--- a/transport/ax25/agwpe/demux.go
+++ b/transport/ax25/agwpe/demux.go
@@ -123,7 +123,9 @@ func (d *demux) NextFrame(kinds ...kind) <-chan frame {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.closed {
-		return nil
+		c := make(chan frame)
+		close(c)
+		return c
 	}
 	req := newFramesReq(1, framesFilter{kinds: kinds})
 	req.once = true

--- a/transport/ax25/agwpe/frame.go
+++ b/transport/ax25/agwpe/frame.go
@@ -1,0 +1,84 @@
+package agwpe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type callsign [10]byte
+
+func callsignFromString(s string) callsign { var c callsign; copy(c[:], s); return c }
+
+func (c callsign) String() string { return strFromBytes(c[:]) }
+
+func strFromBytes(b []byte) string {
+	idx := bytes.IndexByte(b[:], 0x00)
+	if idx < 0 {
+		return string(b)
+	}
+	return string(b[:idx])
+}
+
+// header represents the fixed-size AGWPE header
+type header struct {
+	Port     uint8    // AGWPE Port
+	_        [3]byte  // Reserved
+	DataKind kind     // The frame code
+	_        byte     // Reserved
+	PID      uint8    // Frame PID
+	_        byte     // Reserved
+	From     callsign // From callsign
+	To       callsign // To callsign
+	DataLen  uint32   // Data length
+	_        uint32   // Reserved (User)
+}
+
+func (h *header) ReadFrom(r io.Reader) (int64, error) {
+	return int64(binary.Size(h)), binary.Read(r, binary.LittleEndian, h)
+}
+
+func (h header) WriteTo(w io.Writer) (int64, error) {
+	return int64(binary.Size(h)), binary.Write(w, binary.LittleEndian, h)
+}
+
+// frame represents the variable-size AGWPE frame
+type frame struct {
+	header
+	Data []byte
+}
+
+func (f frame) String() string {
+	return fmt.Sprintf("Port: %d. Kind: %c. From: %v. To: %v, Data: %q", f.Port, f.DataKind, f.From, f.To, f.Data)
+}
+
+func (f frame) WriteTo(w io.Writer) (int64, error) {
+	f.DataLen = uint32(len(f.Data))
+	n, err := f.header.WriteTo(w)
+	if err != nil {
+		return n, err
+	}
+	m, err := w.Write(f.Data)
+	return n + int64(m), err
+}
+
+func (f *frame) ReadFrom(r io.Reader) (int64, error) {
+	n, err := f.header.ReadFrom(r)
+	if err != nil {
+		return n, err
+	}
+	if cap(f.Data) < int(f.header.DataLen) {
+		f.Data = make([]byte, int(f.header.DataLen))
+	} else {
+		f.Data = f.Data[:f.header.DataLen]
+	}
+	m, err := r.Read(f.Data)
+	switch {
+	case err != nil:
+		return n + int64(m), err
+	case m != len(f.Data):
+		return n + int64(m), io.ErrUnexpectedEOF
+	}
+	return n + int64(m), err
+}

--- a/transport/ax25/agwpe/frame_kinds.go
+++ b/transport/ax25/agwpe/frame_kinds.go
@@ -7,21 +7,31 @@ import (
 type kind byte
 
 const (
-	kindLogin         kind = 'P'
-	kindRegister      kind = 'X'
-	kindUnregister    kind = 'x'
-	kindVersionNumber kind = 'R'
+	kindLogin                    kind = 'P'
+	kindRegister                 kind = 'X'
+	kindUnregister               kind = 'x'
+	kindVersionNumber            kind = 'R'
+	kindOutstandingFramesForPort kind = 'y' // Direwolf >= 1.2
+	kindPortCapabilities         kind = 'g'
 
 	kindConnect                  kind = 'C'
 	kindConnectVia               kind = 'v'
 	kindDisconnect               kind = 'd'
 	kindConnectedData            kind = 'D'
-	kindOutstandingFramesForPort kind = 'y' // Direwolf >= 1.2
 	kindOutstandingFramesForConn kind = 'Y' // Direwolf >= 1.4
 )
 
 func versionNumberFrame() frame {
 	return frame{header: header{DataKind: kindVersionNumber}}
+}
+
+func portCapabilitiesFrame(port uint8) frame {
+	return frame{
+		header: header{
+			Port:     port,
+			DataKind: kindPortCapabilities,
+		},
+	}
 }
 
 func connectedDataFrame(port uint8, from, to string, data []byte) frame {

--- a/transport/ax25/agwpe/frame_kinds.go
+++ b/transport/ax25/agwpe/frame_kinds.go
@@ -19,6 +19,7 @@ const (
 	kindDisconnect               kind = 'd'
 	kindConnectedData            kind = 'D'
 	kindOutstandingFramesForConn kind = 'Y' // Direwolf >= 1.4
+	kindUnprotoInformation       kind = 'M'
 )
 
 func versionNumberFrame() frame {
@@ -110,6 +111,15 @@ func connectViaFrame(from, to string, port uint8, digis []string) frame {
 		buf.Write([]byte(callsign[:]))
 	}
 	return frame{header: h, Data: buf.Bytes()}
+}
+
+func unprotoInformationFrame(from, to string, port uint8, data []byte) frame {
+	h := header{
+		DataKind: kindUnprotoInformation,
+		From:     callsignFromString(from),
+		To:       callsignFromString(to),
+	}
+	return frame{header: h, Data: data}
 }
 
 func disconnectFrame(from, to string, port uint8) frame {

--- a/transport/ax25/agwpe/frame_kinds.go
+++ b/transport/ax25/agwpe/frame_kinds.go
@@ -1,0 +1,110 @@
+package agwpe
+
+import (
+	"bytes"
+)
+
+type kind byte
+
+const (
+	kindLogin         kind = 'P'
+	kindRegister      kind = 'X'
+	kindUnregister    kind = 'x'
+	kindVersionNumber kind = 'R'
+
+	kindConnect                  kind = 'C'
+	kindConnectVia               kind = 'v'
+	kindDisconnect               kind = 'd'
+	kindConnectedData            kind = 'D'
+	kindOutstandingFramesForPort kind = 'y' // Direwolf >= 1.2
+	kindOutstandingFramesForConn kind = 'Y' // Direwolf >= 1.4
+)
+
+func versionNumberFrame() frame {
+	return frame{header: header{DataKind: kindVersionNumber}}
+}
+
+func connectedDataFrame(port uint8, from, to string, data []byte) frame {
+	return frame{
+		header: header{
+			Port:     port,
+			DataKind: kindConnectedData,
+			PID:      0xf0,
+			From:     callsignFromString(from),
+			To:       callsignFromString(to),
+			DataLen:  uint32(len(data)),
+		},
+		Data: data,
+	}
+}
+
+func outstandingFramesForConnFrame(port uint8, from, to string) frame {
+	return frame{
+		header: header{
+			Port:     port,
+			DataKind: kindOutstandingFramesForConn,
+			From:     callsignFromString(from),
+			To:       callsignFromString(to),
+		},
+	}
+}
+
+func outstandingFramesForPortFrame(port uint8) frame {
+	return frame{
+		header: header{
+			Port:     port,
+			DataKind: kindOutstandingFramesForPort,
+		},
+	}
+}
+
+func loginFrame(username, password string) frame {
+	data := make([]byte, 255+255)
+	copy(data[:255], username)
+	copy(data[255:], password)
+	return frame{
+		header: header{DataKind: kindLogin},
+		Data:   data,
+	}
+}
+
+func registerCallsignFrame(callsign string, port uint8) frame {
+	h := header{DataKind: kindRegister, Port: port}
+	copy(h.From[:], callsign)
+	return frame{header: h}
+}
+
+func unregisterCallsignFrame(callsign string, port uint8) frame {
+	h := header{DataKind: kindUnregister}
+	copy(h.From[:], callsign)
+	return frame{header: h}
+}
+
+func connectFrame(from, to string, port uint8) frame {
+	h := header{DataKind: kindConnect}
+	copy(h.From[:], from)
+	copy(h.To[:], to)
+	return frame{header: h}
+}
+
+func connectViaFrame(from, to string, port uint8, digis []string) frame {
+	h := header{
+		DataKind: kindConnectVia,
+		From:     callsignFromString(from),
+		To:       callsignFromString(to),
+	}
+	var buf bytes.Buffer
+	buf.WriteByte(uint8(len(digis)))
+	for _, str := range digis {
+		callsign := callsignFromString(str)
+		buf.Write([]byte(callsign[:]))
+	}
+	return frame{header: h, Data: buf.Bytes()}
+}
+
+func disconnectFrame(from, to string, port uint8) frame {
+	h := header{DataKind: kindDisconnect}
+	copy(h.From[:], from)
+	copy(h.To[:], to)
+	return frame{header: h}
+}

--- a/transport/ax25/agwpe/frame_test.go
+++ b/transport/ax25/agwpe/frame_test.go
@@ -1,0 +1,91 @@
+package agwpe
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestHeaderRoundtrip(t *testing.T) {
+	tests := []header{
+		{},
+		{DataLen: 1024},
+		{
+			From:    callsign{'L', 'A', '5', 'N', 'T', 'A', '-', '1', 0x00, 0x00},
+			To:      callsign{'L', 'A', '5', 'N', 'T', 'A', '-', '2', 0x00, 0x00},
+			DataLen: 1024,
+		},
+	}
+
+	for i, h := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			var buf bytes.Buffer
+			if _, err := h.WriteTo(&buf); err != nil {
+				t.Fatal(err)
+			}
+			var got header
+			if _, err := got.ReadFrom(&buf); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(h, got) {
+				t.Error("not equal", h, got)
+			}
+		})
+	}
+}
+
+func TestFrameRoundtrip(t *testing.T) {
+	tests := []frame{
+		{},
+		{
+			header: header{DataLen: 1},
+			Data:   []byte{0x10},
+		},
+	}
+
+	for i, f := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			var buf bytes.Buffer
+			if _, err := f.WriteTo(&buf); err != nil {
+				t.Fatal(err)
+			}
+			var got frame
+			if _, err := got.ReadFrom(&buf); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(f.header, got.header) {
+				t.Error("header not equal")
+			}
+			if !reflect.DeepEqual(f.Data, got.Data) {
+				t.Error("data not equal")
+			}
+		})
+	}
+}
+
+func TestFrameDecode(t *testing.T) {
+	raw := []byte{
+		0x01, 0x00, 0x00, 0x00, 0x4D, 0x00, 0xCF, 0x00, 0x4C, 0x55, 0x37, 0x44, 0x49, 0x44, 0x2D, 0x34,
+		0x00, 0x00, 0x4E, 0x4F, 0x44, 0x45, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0xFF, 0x41, 0x42, 0x52, 0x4F, 0x57, 0x4E,
+	}
+	expect := frame{
+		header: header{
+			Port:     1,
+			DataKind: 'M',
+			PID:      207,
+			From:     callsignFromString("LU7DID-4"),
+			To:       callsignFromString("NODES"),
+			DataLen:  7,
+		},
+		Data: []byte{0xFF, 0x41, 0x42, 0x52, 0x4F, 0x57, 0x4E},
+	}
+	got := frame{}
+	if _, err := got.ReadFrom(bytes.NewReader(raw)); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expect, got) {
+		t.Error("got unexpected output")
+	}
+}

--- a/transport/ax25/agwpe/listener.go
+++ b/transport/ax25/agwpe/listener.go
@@ -1,0 +1,37 @@
+package agwpe
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+var ErrListenerClosed = errors.New("listener closed")
+
+type Listener struct {
+	p *Port
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+func newListener(p *Port) *Listener { return &Listener{p: p, done: make(chan struct{})} }
+
+func (ln *Listener) Accept() (net.Conn, error) {
+	select {
+	case conn, ok := <-ln.p.inboundConns:
+		if !ok {
+			return nil, ErrPortClosed
+		}
+		return conn, nil
+	case <-ln.done:
+		return nil, ErrListenerClosed
+	}
+}
+
+func (ln *Listener) Addr() net.Addr { return addr{dest: ln.p.mycall} }
+
+func (ln *Listener) Close() error {
+	ln.closeOnce.Do(func() { close(ln.done) })
+	return nil
+}

--- a/transport/ax25/agwpe/port.go
+++ b/transport/ax25/agwpe/port.go
@@ -1,0 +1,140 @@
+package agwpe
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/la5nta/wl2k-go/transport"
+)
+
+// Port represents a registered AGWPE Port.
+type Port struct {
+	tnc          *TNC
+	port         uint8
+	mycall       string
+	demux        *demux
+	inboundConns <-chan *Conn
+}
+
+func newPort(tnc *TNC, port uint8, mycall string) *Port {
+	demux := tnc.demux.Chain(framesFilter{port: &port})
+	p := &Port{
+		tnc:    tnc,
+		port:   port,
+		mycall: mycall,
+		demux:  demux,
+	}
+	p.inboundConns = p.handleInbound()
+	return p
+}
+
+func (p *Port) handleInbound() <-chan *Conn {
+	conns := make(chan *Conn)
+	go func() {
+		defer close(conns)
+		connects, cancel := p.demux.Frames(1, framesFilter{
+			kinds: []kind{kindConnect},
+			to:    callsignFromString(p.mycall),
+		})
+		defer cancel()
+		for f := range connects {
+			if !bytes.HasPrefix(f.Data, []byte("*** CONNECTED To ")) {
+				debugf("inbound connection from %s not initiated by remote. ignoring.", f.From)
+				continue
+			}
+			conn := newConn(p, f.From.String())
+			select {
+			case conns <- conn:
+				debugf("inbound connection from %s accepted", f.From)
+			default:
+				// No one is calling Listener.Accept() just now. Close it.
+				conn.Close()
+				debugf("inbound connection from %s refused", f.From)
+			}
+		}
+	}()
+	return conns
+}
+
+func (p *Port) register(ctx context.Context) error {
+	ack := p.demux.NextFrame(kindRegister)
+	if err := p.write(registerCallsignFrame(p.mycall, p.port)); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case f := <-ack:
+		if len(f.Data) != 1 {
+			return fmt.Errorf("unexpected registration response (%c)", f.DataKind)
+		}
+		if f.Data[0] != 0x01 {
+			return fmt.Errorf("callsign in use")
+		}
+		debugf("Port %d registered as %s", p.port, p.mycall)
+		return nil
+	}
+}
+
+func (p *Port) write(f frame) error {
+	if f.Port != p.port {
+		panic("incorrect port in frame")
+	}
+	return p.tnc.write(f)
+}
+
+func (p *Port) Close() error {
+	p.write(unregisterCallsignFrame(p.mycall, p.port))
+	return p.demux.Close()
+}
+
+func (p *Port) DialURLContext(ctx context.Context, url *transport.URL) (net.Conn, error) {
+	if url.Scheme != "ax25" && url.Scheme != "ax25+agwpe" && url.Scheme != "agwpe+ax25" {
+		return nil, fmt.Errorf("unsupported scheme '%s'", url.Scheme)
+	}
+	return p.DialContext(ctx, url.Target, url.Digis...)
+}
+
+func (p *Port) DialContext(ctx context.Context, target string, via ...string) (net.Conn, error) {
+	if p.demux.isClosed() {
+		return nil, ErrPortClosed
+	}
+	c := newConn(p, target, via...)
+	if err := c.connect(ctx); err != nil {
+		c.demux.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (p *Port) Listen() (net.Listener, error) {
+	if p.demux.isClosed() {
+		return nil, ErrPortClosed
+	}
+	return newListener(p), nil
+}
+
+func (p *Port) numOutstandingFrames() (int, error) {
+	resp := p.demux.NextFrame(kindOutstandingFramesForPort)
+	f := outstandingFramesForPortFrame(p.port)
+	if err := p.write(f); err != nil {
+		return 0, err
+	}
+	select {
+	case f, ok := <-resp:
+		if !ok {
+			return 0, nil
+		}
+		if len(f.Data) != 4 {
+			return 0, fmt.Errorf("'%c' frame with unexpected data length", f.DataKind)
+		}
+		return int(binary.LittleEndian.Uint32(f.Data)), nil
+	case <-time.After(3 * time.Second):
+		debugf("'%c' answer timeout. frame kind probably unsupported by TNC.", f.DataKind)
+		return 0, fmt.Errorf("'%c' frame timeout", f.DataKind)
+	}
+}

--- a/transport/ax25/agwpe/port.go
+++ b/transport/ax25/agwpe/port.go
@@ -157,6 +157,14 @@ func (p *Port) Listen() (net.Listener, error) {
 	return newListener(p), nil
 }
 
+func (p *Port) SendUI(data []byte, dst string) error {
+	if p.demux.isClosed() {
+		return ErrPortClosed
+	}
+	f := unprotoInformationFrame(p.mycall, dst, p.port, data)
+	return p.tnc.write(f)
+}
+
 func (p *Port) numOutstandingFrames() (int, error) {
 	resp := p.demux.NextFrame(kindOutstandingFramesForPort)
 	f := outstandingFramesForPortFrame(p.port)

--- a/transport/ax25/agwpe/tnc_port.go
+++ b/transport/ax25/agwpe/tnc_port.go
@@ -1,0 +1,26 @@
+package agwpe
+
+// TNCPort representw a TNC connection with a single registered port.
+type TNCPort struct {
+	TNC
+	Port
+}
+
+// Close closes both the port and TNC.
+func (tp TNCPort) Close() error { tp.Port.Close(); return tp.TNC.Close() }
+
+// OpenPortTCP opens a connection to the TNC and registers a single port.
+//
+// The returned TNCPort is a reference to the combined Port and TNC.
+func OpenPortTCP(addr string, port int, callsign string) (*TNCPort, error) {
+	t, err := OpenTCP(addr)
+	if err != nil {
+		return nil, err
+	}
+	p, err := t.RegisterPort(port, callsign)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	return &TNCPort{*t, *p}, nil
+}

--- a/transport/ax25/ax25.go
+++ b/transport/ax25/ax25.go
@@ -43,6 +43,8 @@ var DefaultDialer = &Dialer{Timeout: 45 * time.Second}
 func init() {
 	transport.RegisterDialer("ax25", DefaultDialer)
 	transport.RegisterDialer("serial-tnc", DefaultDialer)
+	transport.RegisterDialer("ax25+linux", DefaultDialer)
+	transport.RegisterDialer("ax25+serial-tnc", DefaultDialer)
 }
 
 type addr interface {
@@ -120,14 +122,14 @@ type Dialer struct {
 	Timeout time.Duration
 }
 
-// DialURL dials ax25:// and serial-tnc:// URLs.
+// DialURL dials ax25://, ax25+linux://, serial-tnc:// and ax25+serial-tnc:// URLs.
 //
 // See DialURLContext.
 func (d Dialer) DialURL(url *transport.URL) (net.Conn, error) {
 	return d.DialURLContext(context.Background(), url)
 }
 
-// DialURLContext dials ax25:// and serial-tnc:// URLs.
+// DialURLContext dials ax25://, ax25+linux://, serial-tnc:// and ax25+serial-tnc:// URLs.
 //
 // If the context is cancelled while dialing, the connection may be closed gracefully before returning an error.
 func (d Dialer) DialURLContext(ctx context.Context, url *transport.URL) (net.Conn, error) {
@@ -137,7 +139,7 @@ func (d Dialer) DialURLContext(ctx context.Context, url *transport.URL) (net.Con
 	}
 
 	switch url.Scheme {
-	case "ax25":
+	case "ax25", "ax25+linux":
 		ctx, cancel := context.WithTimeout(ctx, d.Timeout)
 		defer cancel()
 		conn, err := DialAX25Context(ctx, url.Host, url.User.Username(), target)
@@ -146,7 +148,7 @@ func (d Dialer) DialURLContext(ctx context.Context, url *transport.URL) (net.Con
 			err = fmt.Errorf("Dial timeout")
 		}
 		return conn, err
-	case "serial-tnc":
+	case "serial-tnc", "ax25+serial-tnc":
 		// TODO: This is some badly designed legacy stuff. Need to re-think the whole
 		// serial-tnc scheme. See issue #34.
 		hbaud := HBaud(1200)


### PR DESCRIPTION
Implements the AGWPE protocol for AX.25 connections through AGWPE enabled TNCs. Both listen and dial. It's URL dialer supports the schemes `ax25://` and `ax25+agwpe://`.

Closes #57.