### PR TITLE
fixed compilation with `TAGS=libhamlib` and a warning

### DIFF
--- a/rigcontrol/hamlib/helpers.c
+++ b/rigcontrol/hamlib/helpers.c
@@ -7,6 +7,8 @@
 
 #include <hamlib/rig.h>
 
+extern void rigListCb(const struct rig_caps *rc);
+
 void setBaudRate(RIG *r, int rate) {
 	r->state.rigport.parm.serial.rate = rate;
 }

--- a/rigcontrol/hamlib/libhamlib.go
+++ b/rigcontrol/hamlib/libhamlib.go
@@ -80,7 +80,7 @@ func OpenSerial(model RigModel, path string, baudrate int) (*SerialRig, error) {
 	C.setBaudRate(rig, C.int(baudrate))
 
 	// Set path to tty
-	C.strncpy(&rig.state.rigport.pathname[0], C.CString(path), C.FILPATHLEN-1)
+	C.strncpy(&rig.state.rigport.pathname[0], C.CString(path), C.HAMLIB_FILPATHLEN-1)
 
 	err := codeToError(C.rig_open(rig))
 	if err != nil {


### PR DESCRIPTION
with hamlib v4.2 the symbol `FILPATHLEN` was renamed `HAMLIB_FILPATHLEN`
(precise commit: https://github.com/Hamlib/Hamlib/commit/3d613519d52b8520d7a66f03389b2a2b3abf0c0a)
