### PR TITLE
Fix VFOMode to check for correct response

### DIFF
--- a/rigcontrol/hamlib/rigctld.go
+++ b/rigcontrol/hamlib/rigctld.go
@@ -121,7 +121,7 @@ func (r *TCPRig) VFOMode() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return resp == "CHKVFO 1", nil
+	return strings.TrimPrefix(resp, "CHKVFO ") == "1", nil
 }
 
 // Gets the dial frequency for this VFO.


### PR DESCRIPTION
Previous, VFOMode() was expecting the response `CHKVFO 1` from `rigctld`
when running in VFO mode, but in fact `rigctld` responds with the string
`1`:

    $ nc localhost 4532
    \chk_vfo
    1

Closes la5nta/pat#427
