### PR TITLE
midPayload ignored time.Time argument

### DIFF
--- a/fbb/mid.go
+++ b/fbb/mid.go
@@ -20,5 +20,5 @@ func GenerateMid(callsign string) string {
 }
 
 func midPayload(callsign string, t time.Time) []byte {
-	return []byte(fmt.Sprintf("%s-%s", time.Now(), callsign))
+	return []byte(fmt.Sprintf("%s-%s", t, callsign))
 }


### PR DESCRIPTION
Minor but code does not seem to be doing what appears to be intended.