### PR TITLE
agwpe: Fix Port field not set in several frame builders

### DIFF
--- a/transport/ax25/agwpe/frame.go
+++ b/transport/ax25/agwpe/frame.go
@@ -73,12 +73,6 @@ func (f *frame) ReadFrom(r io.Reader) (int64, error) {
 	} else {
 		f.Data = f.Data[:f.header.DataLen]
 	}
-	m, err := r.Read(f.Data)
-	switch {
-	case err != nil:
-		return n + int64(m), err
-	case m != len(f.Data):
-		return n + int64(m), io.ErrUnexpectedEOF
-	}
+	m, err := io.ReadFull(r, f.Data)
 	return n + int64(m), err
 }

--- a/transport/ax25/agwpe/frame_kinds.go
+++ b/transport/ax25/agwpe/frame_kinds.go
@@ -86,7 +86,7 @@ func registerCallsignFrame(callsign string, port uint8) frame {
 }
 
 func unregisterCallsignFrame(callsign string, port uint8) frame {
-	h := header{DataKind: kindUnregister}
+	h := header{DataKind: kindUnregister, Port: port}
 	copy(h.From[:], callsign)
 	return frame{header: h}
 }
@@ -96,6 +96,7 @@ func connectFrame(from, to string, port uint8, digis []string) frame {
 		return connectViaFrame(from, to, port, digis)
 	}
 	return frame{header: header{
+		Port:     port,
 		DataKind: kindConnect,
 		From:     callsignFromString(from),
 		To:       callsignFromString(to),
@@ -104,6 +105,7 @@ func connectFrame(from, to string, port uint8, digis []string) frame {
 
 func connectViaFrame(from, to string, port uint8, digis []string) frame {
 	h := header{
+		Port:     port,
 		DataKind: kindConnectVia,
 		From:     callsignFromString(from),
 		To:       callsignFromString(to),
@@ -119,7 +121,9 @@ func connectViaFrame(from, to string, port uint8, digis []string) frame {
 
 func unprotoInformationFrame(from, to string, port uint8, data []byte) frame {
 	h := header{
+		Port:     port,
 		DataKind: kindUnprotoInformation,
+		PID:      0xf0,
 		From:     callsignFromString(from),
 		To:       callsignFromString(to),
 	}
@@ -127,7 +131,7 @@ func unprotoInformationFrame(from, to string, port uint8, data []byte) frame {
 }
 
 func disconnectFrame(from, to string, port uint8) frame {
-	h := header{DataKind: kindDisconnect}
+	h := header{DataKind: kindDisconnect, Port: port}
 	copy(h.From[:], from)
 	copy(h.To[:], to)
 	return frame{header: h}

--- a/transport/ax25/agwpe/frame_test.go
+++ b/transport/ax25/agwpe/frame_test.go
@@ -64,6 +64,32 @@ func TestFrameRoundtrip(t *testing.T) {
 	}
 }
 
+func TestFrameBuildersSetPort(t *testing.T) {
+	var port uint8 = 3
+	from, to := "N0CALL", "N0ONE"
+
+	frames := map[string]frame{
+		"connectFrame":              connectFrame(from, to, port, nil),
+		"connectViaFrame":           connectFrame(from, to, port, []string{"DIGI1"}),
+		"disconnectFrame":           disconnectFrame(from, to, port),
+		"unregisterCallsignFrame":   unregisterCallsignFrame(from, port),
+		"unprotoInformationFrame":   unprotoInformationFrame(from, to, port, []byte("test")),
+		"registerCallsignFrame":     registerCallsignFrame(from, port),
+		"portCapabilitiesFrame":     portCapabilitiesFrame(port),
+		"connectedDataFrame":        connectedDataFrame(port, from, to, []byte("test")),
+		"outstandingFramesForPort":  outstandingFramesForPortFrame(port),
+		"outstandingFramesForConn":  outstandingFramesForConnFrame(port, from, to),
+	}
+
+	for name, f := range frames {
+		t.Run(name, func(t *testing.T) {
+			if f.header.Port != port {
+				t.Errorf("got Port=%d, want %d", f.header.Port, port)
+			}
+		})
+	}
+}
+
 func TestFrameDecode(t *testing.T) {
 	raw := []byte{
 		0x01, 0x00, 0x00, 0x00, 0x4D, 0x00, 0xCF, 0x00, 0x4C, 0x55, 0x37, 0x44, 0x49, 0x44, 0x2D, 0x34,


### PR DESCRIPTION
## Summary

Several AGWPE frame builder functions accept a `port` parameter but don't assign it to the header struct, so it defaults to `0`. When `Port.write()` validates `f.Port == p.port`, any port other than 0 panics with `"incorrect port in frame"`.

**Fixed functions:**
- `connectFrame()` — Port not set when no digipeaters
- `connectViaFrame()` — Port not set
- `disconnectFrame()` — Port not set
- `unregisterCallsignFrame()` — Port not set
- `unprotoInformationFrame()` — Port not set

**Additional fixes:**
- Set `PID=0xF0` on `unprotoInformationFrame` per AGWPE spec (was defaulting to 0)
- Replace `r.Read(f.Data)` with `io.ReadFull` in `frame.ReadFrom` to handle short reads on TCP

## Reproduction

Configure PAT with `radio_port` set to any value other than 0 and connect via AGWPE:

```json
{
  "agwpe": {
    "addr": "127.0.0.1:8000",
    "radio_port": 1
  }
}
```

PAT panics immediately when `connect()` calls `Port.write(connectFrame(...))`.

## Test plan

- [x] Added `TestFrameBuildersSetPort` covering all 10 frame builder functions
- [x] All existing tests pass (`go test ./transport/ax25/agwpe/...`)
- [x] Verified OTA: full Winlink CMS round-trip on AGWPE port 1 via Mobilinkd TNC3 with PAT v1.0.0 — sent and received messages successfully